### PR TITLE
Load openFileLoaderDialog FileName initially empty

### DIFF
--- a/MyNeuralNetwork/MainForm.Designer.cs
+++ b/MyNeuralNetwork/MainForm.Designer.cs
@@ -114,7 +114,7 @@
             this.stateErrorsChart = new System.Windows.Forms.DataVisualization.Charting.Chart();
             this.trainSymbol = new System.Windows.Forms.Label();
             this.StopTrainingButton = new System.Windows.Forms.Button();
-            this.openFileDialog1 = new System.Windows.Forms.OpenFileDialog();
+            this.openFileLoaderDialog = new System.Windows.Forms.OpenFileDialog();
             this.saveFileDialog1 = new System.Windows.Forms.SaveFileDialog();
             this.errorsChart = new System.Windows.Forms.DataVisualization.Charting.Chart();
             this.signalParamText = new System.Windows.Forms.TextBox();
@@ -732,7 +732,7 @@
             // 
             // openFileDialog1
             // 
-            this.openFileDialog1.FileName = "openFileDialog1";
+            this.openFileLoaderDialog.FileName = string.Empty;
             // 
             // errorsChart
             // 
@@ -927,7 +927,7 @@
         private System.Windows.Forms.CheckBox trainModeBox;
         private System.Windows.Forms.Label trainSymbol;
         private System.Windows.Forms.Button StopTrainingButton;
-        private System.Windows.Forms.OpenFileDialog openFileDialog1;
+        private System.Windows.Forms.OpenFileDialog openFileLoaderDialog;
         private System.Windows.Forms.SaveFileDialog saveFileDialog1;
         public System.Windows.Forms.ListBox log;
         public System.Windows.Forms.TextBox iterationsText;

--- a/MyNeuralNetwork/MainForm.cs
+++ b/MyNeuralNetwork/MainForm.cs
@@ -898,11 +898,11 @@ namespace MyNeuralNetwork
 
             chartCount++;
 
-            openFileDialog1.InitialDirectory = Directory.GetCurrentDirectory();
-            openFileDialog1.Filter = "Model File (*.mdl)|*.mdl;";
+            openFileLoaderDialog.InitialDirectory = Directory.GetCurrentDirectory();
+            openFileLoaderDialog.Filter = "Model File (*.mdl)|*.mdl;";
 
-            if (openFileDialog1.ShowDialog() == DialogResult.OK)
-               path = openFileDialog1.FileName;
+            if (openFileLoaderDialog.ShowDialog() == DialogResult.OK)
+               path = openFileLoaderDialog.FileName;
             else
                 return;
 


### PR DESCRIPTION
User interface and usability fix when user try to load openFileLoaderDialog FileName initially empty